### PR TITLE
chore(bump mathlib)

### DIFF
--- a/lean_modifications/tactic_modifications.lean
+++ b/lean_modifications/tactic_modifications.lean
@@ -303,6 +303,6 @@ else tactic.step t
 end pr
 
 -- redefined istep to do proof recording
-meta def tactic.istep {α : Type u} (line0 col0 : ℕ) (line col : ℕ) (t : tactic α) : tactic unit :=
+meta def tactic.istep {α : Type u} (line0 col0 line col ast : ℕ) (t : tactic α) : tactic unit :=
 λ s, (@scope_trace _ line col (λ _, pr.step_and_record line col t s)).clamp_pos line0 line col
 --PR END MODIFICATION

--- a/lean_proof_recording/pipeline/insert_proof_recording_code.py
+++ b/lean_proof_recording/pipeline/insert_proof_recording_code.py
@@ -34,8 +34,8 @@ CONV_INTERACTIVE_LEAN_FILE_MODIFICATIONS = Path(
     "lean_modifications/conv_interactive_modifications.lean"
 )
 
-ISTEP_CODE = """meta def istep {α : Type u} (line0 col0 : ℕ) (line col : ℕ) (t : tactic α) : tactic unit :=
-λ s, (@scope_trace _ line col (λ _, step t s)).clamp_pos line0 line col
+ISTEP_CODE = """meta def istep {α : Type u} (line0 col0 line col ast : ℕ) (t : tactic α) : tactic unit :=
+λ s, (@scope_trace _ line col (λ _, with_ast ast (step t) s)).clamp_pos line0 line col
 """
 
 TACTIC_ITACTIC_CODE = """meta def itactic : Type :=

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lean_proof_recording"
 version = "0.1"
-lean_version = "leanprover-community/lean:3.30.0"
+lean_version = "leanprover-community/lean:3.33.0"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "9a8dcb9be408e7ae8af9f6832c08c021007f40ec"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "4a02fd3bf80d43fd7965c1bfc3361765d828d0eb"}


### PR DESCRIPTION
@jasonrute running in some issues after bumping:

```
=============================================                                               
Change lean path to _target/deps/lean/library
=============================================
Path changed                                 
Insert tactic tracing code                                 
Traceback (most recent call last):                   
  File "/opt/conda/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)                                
  File "/opt/conda/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)                            
  File "/root/code/formal/formal/lean/lean_proof_recording/lean_proof_recording/pipeline/insert_proof_recording_code.py", line 443, in <module>
    main()                                                                                                  
  File "/root/code/formal/formal/lean/lean_proof_recording/lean_proof_recording/pipeline/insert_proof_recording_code.py", line 429, in main
    insert_tactic_tracing_code(dryrun=dryrun, sexp=sexp)
  File "/root/code/formal/formal/lean/lean_proof_recording/lean_proof_recording/pipeline/insert_proof_recording_code.py", line 79, in insert_tactic_tracing_code
    l1, l2 = find_code_location(TACTIC_LEAN_FILE, ISTEP_CODE)              
  File "/root/code/formal/formal/lean/lean_proof_recording/lean_proof_recording/pipeline/insert_proof_recording_code.py", line 60, in find_code_location
    f"Cannot find an exact instance of the below code in the file {file}:\n{code_string}"
Exception: Cannot find an exact instance of the below code in the file _target/deps/lean/library/init/meta/tactic.lean:
meta def istep {α : Type u} (line0 col0 : ℕ) (line col : ℕ) (t : tactic α) : tactic unit :=
λ s, (@scope_trace _ line col (λ _, step t s)).clamp_pos line0 line col
```

Then builds takes place but nothing is outputted, should be an easy fix?